### PR TITLE
Updated docblock, short array syntax, missing file Krixon/JsonRpc/Fau…

### DIFF
--- a/Krixon/JsonRpc/Fault.php
+++ b/Krixon/JsonRpc/Fault.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * @category   Krixon
+ * @package    Krixon_JsonRpc
+ */
+
+
+/**
+ * Zend_Exception
+ */
+require_once 'Zend/XmlRpc/Fault.php';
+
+
+/**
+ * @category   Zend
+ * @package    Krixon_JsonRpc
+ */
+class Krixon_JsonRpc_Fault extends Zend_XmlRpc_Fault
+{
+
+}

--- a/Krixon/JsonRpc/Request.php
+++ b/Krixon/JsonRpc/Request.php
@@ -43,7 +43,7 @@ class Krixon_JsonRpc_Request
      * @var string
      */
     protected $_id;
-    
+
     /**
      * Json request string
      * @var string
@@ -54,7 +54,10 @@ class Krixon_JsonRpc_Request
      * Method parameters
      * @var array
      */
-    protected $_params = array();
+    protected $_params = [];
+
+    /** @var Zend_XmlRpc_Fault */
+    protected $_fault;
 
     /**
      * Create a new JSON-RPC request
@@ -71,7 +74,7 @@ class Krixon_JsonRpc_Request
         if (null !== $params) {
             $this->setParams($params);
         }
-        
+
         $this->setId($id);
     }
 
@@ -125,13 +128,13 @@ class Krixon_JsonRpc_Request
     {
         return $this->_method;
     }
-    
+
     /**
      * Set the id of this request
      *
      * @param string|null $id An id to use for the request, or null to have an id
      *                        generated automatically
-     * @return Krixon_JsonRpc_Request
+     * @return $this
      */
     public function setId($id = null)
     {
@@ -141,7 +144,7 @@ class Krixon_JsonRpc_Request
         $this->_id = $id;
         return $this;
     }
-    
+
     /**
      * Retrieve current request id
      *
@@ -238,12 +241,12 @@ class Krixon_JsonRpc_Request
      * @return string
      */
     public function saveJson()
-    {        
-        $data = array(
+    {
+        $data = [
             'jsonrpc' => '2.0',
             'method'  => $this->getMethod(),
             'id'      => $this->getId()
-        );
+        ];
         $params = $this->getParams();
         if (!empty($params)) {
             $data['params'] = $params;
@@ -260,7 +263,12 @@ class Krixon_JsonRpc_Request
     {
         return $this->saveJson();
     }
-    
+
+    /**
+     * Generate a unique id for this request
+     *
+     * @return string
+     */
     private function _generateId()
     {
         return uniqid();

--- a/Krixon/JsonRpc/Request/Http.php
+++ b/Krixon/JsonRpc/Request/Http.php
@@ -46,7 +46,7 @@ class Krixon_JsonRpc_Request_Http extends Krixon_JsonRpc_Request
     {
         $json = @file_get_contents('php://input');
         if (!$json) {
-            throw new Krixon_JsonRpc_Fault('Unable to read HTTP POST data');
+            throw new Krixon_JsonRpc_Exception('Unable to read HTTP POST data');
             return;
         }
 

--- a/Krixon/JsonRpc/Request/Stdin.php
+++ b/Krixon/JsonRpc/Request/Stdin.php
@@ -38,7 +38,7 @@ class Krixon_JsonRpc_Request_Stdin extends Krixon_JsonRpc_Request
     {
         $fh = fopen('php://stdin', 'r');
         if (!$fh) {
-            throw new Krixon_JsonRpc_Server_Exception('Could not read from stdin');
+            throw new Krixon_JsonRpc_Exception('Could not read from stdin');
         }
 
         $json = '';

--- a/Krixon/JsonRpc/Response.php
+++ b/Krixon/JsonRpc/Response.php
@@ -19,16 +19,16 @@ require_once 'Krixon/JsonRpc/Response/Exception.php';
  */
 class Krixon_JsonRpc_Response
 {
-    
+
     const TYPE_OBJECT = 0;
     const TYPE_ARRAY  = 1;
-    
+
     /**
      * The id of the request by which to validate the response
      * @var string
      */
     protected $_id;
-    
+
     /**
      * Return value
      * @var mixed
@@ -56,19 +56,19 @@ class Krixon_JsonRpc_Response
         $this->setId($id);
         $this->setReturnValue($return);
     }
-    
+
     /**
      * Set the id of the request
      *
      * @param string $id The id of the request used to generate this response
-     * @return Krixon_JsonRpc_Response
+     * @return $this
      */
     public function setId($id)
     {
         $this->_id = $id;
         return $this;
     }
-    
+
     /**
      * Retrieve request id
      *
@@ -83,7 +83,7 @@ class Krixon_JsonRpc_Response
      * Set encoding to use in response
      *
      * @param string $encoding
-     * @return Krixon_JsonRpc_Response
+     * @return $this
      */
     public function setEncoding($encoding)
     {
@@ -138,20 +138,16 @@ class Krixon_JsonRpc_Response
         if (!is_string($response)) {
             throw new Krixon_JsonRpc_Response_Exception('Invalid JSON provided');
         }
-        
-        if (self::TYPE_ARRAY == $type) {
-            $type = Zend_Json::TYPE_ARRAY;
-        } else {
-            $type = Zend_Json::TYPE_OBJECT;
-        }
-        
+
+        $type = $type == self::TYPE_ARRAY ? Zend_Json::TYPE_ARRAY : Zend_Json::TYPE_OBJECT;
+
         try {
             $json = Zend_Json::decode($response, $type);
         } catch (Zend_Json_Exception $e) {
-            throw new Krixon_JsonRpc_Response_Exception('Failed to parse request');
+            throw new Krixon_JsonRpc_Response_Exception('Failed to parse response: '.$response);
         }
-        
-        $responseId = self::TYPE_ARRAY == $type ? $json['id'] : $json->id;
+
+        $responseId = $type == self::TYPE_ARRAY ? $json['id'] : $json->id;
         if ($this->getId() != $responseId) {
             throw new Krixon_JsonRpc_Response_Exception('Invalid response. Id does not match request id');
         }
@@ -167,8 +163,8 @@ class Krixon_JsonRpc_Response
     public function saveJson()
     {
         $value = $this->getReturnValue();
-        if (null === $value) {
-            $value = array();
+        if ($value === null) {
+            $value = [];
         }
         return Zend_Json::encode($value);
     }


### PR DESCRIPTION
…lt.php.

Also added the ability to set the response's JSON type.

```php
$client = new Krixon_JsonRpc_Client($url);
$client->setResultType(Krixon_JsonRpc_Response::TYPE_ARRAY);
$session = $client->call('login', [$param1, $param2])['result'] ?? '';
```